### PR TITLE
Rel.0.1.1 complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ This application is NOT designed for commercial use and should NOT be copied for
 - `Vehicle` to String method is updated accordingly.
 - Code cleanup conducted within the `CRAnalyzer` class.
 
+- Added logic to fetch the vehicle odometer information.
+
 ---
 
 ## Future Improvements / Work-in-Progress
@@ -67,6 +69,13 @@ This application is NOT designed for commercial use and should NOT be copied for
 > Vehicle odometer information
 
 - Add logic to fetch the vehicle odometer information.
+  Current logic does not have any consideration for this.
+- Add logic to limit for the max odometer reading.
+  Current logic does not have any consideration for this.
+
+> Vehicle VIN
+
+- Add logic to fetch the vehicle VIN information.
   Current logic does not have any consideration for this.
   
 > Vehicle status analysis

--- a/README.md
+++ b/README.md
@@ -61,15 +61,12 @@ This application is NOT designed for commercial use and should NOT be copied for
 - Added logic to fetch the vehicle odometer information.
   - Introduced new logic to eliminate vehicles with odometer readings higer
     than certain parameter defined in `application.config`
+- Added logic to fetch the vehicle VIN and parse it with a special design
+  if the VIN is of correct length.
 
 ---
 
 ## Future Improvements / Work-in-Progress
-
-> Vehicle VIN
-
-- Add logic to fetch the vehicle VIN information.
-  Current logic does not have any consideration for this.
   
 > Vehicle status analysis
 
@@ -90,7 +87,8 @@ This application is NOT designed for commercial use and should NOT be copied for
 
 - Information to store:
   - Vehicle unique ID (primary key, auto-increment)
-  - Vehicle year and make/model
+  - Vehicle year 
+  - Vehicle make/model
   - Vehicle VIN
   - Vehicle odometer reading
   - Vehicle auction

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Authors
 
-* **Shahin 'Sean' Gadimov** - *Idea and initial work* [ea-q-le](https://github.com/ea-q-le)
+* **Shahin 'Sean' Gadimov** - *Idea and initial work* - [ea-q-le](https://github.com/ea-q-le)
 
 ---
 
@@ -54,16 +54,15 @@ This application is NOT designed for commercial use and should NOT be copied for
   in case year of the vehicle is not advertised.
   Such vehicles are skipped so that the year is assigned as `-1`.
 
+- Vehicle title is being fetched from the `Auction` page insted of 
+  from within the CR window. Thus eliminating the need to additional
+  maintenance on the CR window.
+- `Vehicle` to String method is updated accordingly.
+- Code cleanup conducted within the `CRAnalyzer` class.
+
 ---
 
 ## Future Improvements / Work-in-Progress
-
-> Vehicle year analysis
-
-- Add logic to eliminate the vehicles younger than certain age.
-  Current logic only limits the older vehicles per specifications.
-- Update the code to fetch the vehicle information from the `Auction` window.
-  Current logic fetches the information from within the `CR` window.
   
 > Vehicle odometer information
 

--- a/README.md
+++ b/README.md
@@ -63,15 +63,14 @@ This application is NOT designed for commercial use and should NOT be copied for
     than certain parameter defined in `application.config`
 - Added logic to fetch the vehicle VIN and parse it with a special design
   if the VIN is of correct length.
+- Added logic to analyze vehicle status (whether it is sold or still 
+  available) based on the presence of the 'Proxy bid' element.
+  Currently, vehicles with 'SOLD' status are ignored and no further CR
+  analysis is conducted. This logic can be adjusted in the future.
 
 ---
 
 ## Future Improvements / Work-in-Progress
-  
-> Vehicle status analysis
-
-- Add logic to validate whether the vehicle is already `SOLD`.
-  Current logic does not have any consideration for this.
   
 > Auction analysis
 
@@ -95,6 +94,7 @@ This application is NOT designed for commercial use and should NOT be copied for
   - Vehicle run lane
   - Vehicle run date
   - Vehicle announcements
+  - Vehicle status (available or sold)
 - Logic to implement:
   - Before analyzing the CR of a vehicle, determine
     whether the vehicle is already in the DB (i.e. it has been analyzed before),

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-##Authors
+## Authors
 
 * **Shahin 'Sean' Gadimov** - *Idea and initial work* [ea-q-le](https://github.com/ea-q-le)
 
@@ -37,11 +37,22 @@ This application is NOT designed for commercial use and should NOT be copied for
 ## Version History
 
 > **Release 0.1** on 5/10/2020
+
 **Release Notes:**
 
 - The complete end-to-end run achieved
 - Email received per given specifications and limitations
 - Common errors and exceptions are handled
+
+> **Release 0.1.1** on 5/12/2020
+
+**Release Notes:**
+
+- Introduced new logic to eliminate vehicles younger than certain year
+- The parameter can be adjusted from `application.config`
+- Additional check was placed to eliminate potential code failure
+  in case year of the vehicle is not advertised.
+  Such vehicles are skipped so that the year is assigned as `-1`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,29 +49,22 @@ This application is NOT designed for commercial use and should NOT be copied for
 **Release Notes:**
 
 - Introduced new logic to eliminate vehicles younger than certain year
-- The parameter can be adjusted from `application.config`
-- Additional check was placed to eliminate potential code failure
-  in case year of the vehicle is not advertised.
-  Such vehicles are skipped so that the year is assigned as `-1`.
-
+  - The parameter can be adjusted from `application.config`
+  - Additional check was placed to eliminate potential code failure
+    in case year of the vehicle is not advertised.
+    Such vehicles are skipped so that the year is assigned as `-1`.
 - Vehicle title is being fetched from the `Auction` page insted of 
   from within the CR window. Thus eliminating the need to additional
   maintenance on the CR window.
-- `Vehicle` to String method is updated accordingly.
-- Code cleanup conducted within the `CRAnalyzer` class.
-
+  - `Vehicle` to String method is updated accordingly.
+  - Code cleanup conducted within the `CRAnalyzer` class.
 - Added logic to fetch the vehicle odometer information.
+  - Introduced new logic to eliminate vehicles with odometer readings higer
+    than certain parameter defined in `application.config`
 
 ---
 
 ## Future Improvements / Work-in-Progress
-  
-> Vehicle odometer information
-
-- Add logic to fetch the vehicle odometer information.
-  Current logic does not have any consideration for this.
-- Add logic to limit for the max odometer reading.
-  Current logic does not have any consideration for this.
 
 > Vehicle VIN
 

--- a/application.config
+++ b/application.config
@@ -16,3 +16,6 @@ emailLimit=100
 #Vehicle year criteria
 youngerThan=2010
 olderThan=2017
+
+#Vehicle odometer criteria
+lowerThan=150000

--- a/application.config
+++ b/application.config
@@ -15,3 +15,4 @@ emailLimit=100
 
 #Vehicle year criteria
 youngerThan=2010
+olderThan=2017

--- a/src/main/java/analyzers/CRAnalyzer.java
+++ b/src/main/java/analyzers/CRAnalyzer.java
@@ -8,13 +8,18 @@ import utilities.Driver;
 
 public class CRAnalyzer {
 	
+	/**
+	 * The method will 'try' to fetch the Announcements from
+	 * the CR window that the Driver is currently focused on.
+	 * It will set the announcement to the given Vehicle object.
+	 * This method is designed to work with certain version of CR windows.
+	 * 
+	 * @param vehicle to which the announcement will be set to
+	 * @return boolean value whether the method was successful in
+	 * 		   finding and setting the announcements
+	 */
 	public static boolean isVersion1(Vehicle vehicle) {
 		try {
-			// fetch the vehicle information
-			vehicle.setTitle(Driver.getDriver()
-					.findElement(By.cssSelector("h2[class='ymmt-headline']"))
-						.getText());
-
 			// fetch the vehicle ANNOUCEMENTS
 			vehicle.setAnnouncement(Driver.getDriver()
 					.findElement(By.id("cr_announcements"))
@@ -27,13 +32,18 @@ public class CRAnalyzer {
 		}
 	}
 	
+	/**
+	 * The method will 'try' to fetch the Announcements from
+	 * the CR window that the Driver is currently focused on.
+	 * It will set the announcement to the given Vehicle object.
+	 * This method is designed to work with certain version of CR windows.
+	 * 
+	 * @param vehicle to which the announcement will be set to
+	 * @return boolean value whether the method was successful in
+	 * 		   finding and setting the announcements
+	 */
 	public static boolean isVersion2(Vehicle vehicle) {
-		try {
-			// fetch the vehicle information
-			vehicle.setTitle(Driver.getDriver()
-					.findElement(By.cssSelector("td[colspan='3']"))
-						.getText());
-			
+		try {			
 			// fetch the vehicle ANNOUNCEMENTS
 			vehicle.setAnnouncement(Driver.getDriver()
 					.findElement(By.cssSelector(".announcements>.mainfont"))
@@ -46,13 +56,18 @@ public class CRAnalyzer {
 		}
 	}
 	
+	/**
+	 * The method will 'try' to fetch the Announcements from
+	 * the CR window that the Driver is currently focused on.
+	 * It will set the announcement to the given Vehicle object.
+	 * This method is designed to work with certain version of CR windows.
+	 * 
+	 * @param vehicle to which the announcement will be set to
+	 * @return boolean value whether the method was successful in
+	 * 		   finding and setting the announcements
+	 */
 	public static boolean isVersion3(Vehicle vehicle) {
 		try {
-			// fetch the vehicle information
-			vehicle.setTitle(Driver.getDriver()
-					.findElement(By.className("vehicleSummary"))
-						.getText());
-
 			// fetch the vehicle ANNOUNCEMENTS
 			vehicle.setAnnouncement(Driver.getDriver()
 					.findElement(By.cssSelector(".announcements>td"))

--- a/src/main/java/beans/Vehicle.java
+++ b/src/main/java/beans/Vehicle.java
@@ -20,14 +20,20 @@ public class Vehicle {
 	private String lane;
 	private short year;
 	private String title;
+	private int odometer;
 	private String announcement;
 	
 	private static List<Vehicle> matches = new ArrayList<Vehicle>();
 	
 	public Vehicle() { }
-	public Vehicle(String auction, String title, String announcement) {
+	public Vehicle(String auction, String lane, 
+			short year, String title, int odometer, 
+			String announcement) {
 		this.auction = auction;
+		this.lane = lane;
+		this.year = year;
 		this.title = title;
+		this.odometer = odometer;
 		this.announcement = announcement;
 	}
 	
@@ -39,20 +45,6 @@ public class Vehicle {
 			auction = auction.substring(0, auction.indexOf(':') -1);
 		this.auction = auction;
 	}
-	public String getTitle() {
-		return title;
-	}
-	public void setTitle(String title) {
-		this.title = title;
-	}
-	public String getAnnouncement() {
-		return announcement;
-	}
-	public void setAnnouncement(String announcement) {
-		if (announcement.contains("Announcements\n"))
-			announcement = announcement.replace("Announcements\n", "");
-		this.announcement = announcement;
-	}	
 	public String getLane() {
 		return lane;
 	}
@@ -65,7 +57,27 @@ public class Vehicle {
 	public void setYear(short year) {
 		this.year = year;
 	}
-	
+	public String getTitle() {
+		return title;
+	}
+	public void setTitle(String title) {
+		this.title = title;
+	}
+	public int getOdometer() {
+		return odometer;
+	}
+	public void setOdometer(int odometer) {
+		this.odometer = odometer;
+	}
+	public String getAnnouncement() {
+		return announcement;
+	}
+	public void setAnnouncement(String announcement) {
+		if (announcement.contains("Announcements\n"))
+			announcement = announcement.replace("Announcements\n", "");
+		this.announcement = announcement;
+	}	
+		
 	public static List<Vehicle> getMatches() {
 		return matches;
 	}
@@ -76,7 +88,7 @@ public class Vehicle {
 	@Override
 	public String toString() {
 		return auction + "\tLane: " + lane
-				+ "\n" + year + " " + title
+				+ "\n" + year + " " + title + " w/ " + odometer + " miles"
 				+ "\n*Announcements*: " + announcement;
 	}
 	

--- a/src/main/java/beans/Vehicle.java
+++ b/src/main/java/beans/Vehicle.java
@@ -24,6 +24,7 @@ public class Vehicle {
 	private short year;
 	private String title;
 	private int odometer;
+	private String vin;
 	private String announcement;
 	
 	private static List<Vehicle> matches = new ArrayList<Vehicle>();
@@ -72,6 +73,16 @@ public class Vehicle {
 	public void setOdometer(int odometer) {
 		this.odometer = odometer;
 	}
+	public String getVIN() {
+		return vin;
+	}
+	public void setVIN(String vin) {
+		this.vin = (vin.length() == 17) 
+				? vin.substring(0, 9) + " " 
+					+ vin.substring(9, 11) + " [ "
+					+ vin.substring(11) + " ]"
+				: vin;
+	}
 	public String getAnnouncement() {
 		return announcement;
 	}
@@ -92,6 +103,7 @@ public class Vehicle {
 	public String toString() {
 		return auction + "\tLane: " + lane
 				+ "\n" + year + " " + title + " w/ " + odometer + " miles"
+				+ "\n[VIN]: " + vin 
 				+ "\n*Announcements*: " + announcement;
 	}
 	

--- a/src/main/java/beans/Vehicle.java
+++ b/src/main/java/beans/Vehicle.java
@@ -76,8 +76,8 @@ public class Vehicle {
 	@Override
 	public String toString() {
 		return auction + "\tLane: " + lane
-				+ "\n" + title
-				+ "\nANNOUNCEMENT: " + announcement;
+				+ "\n" + year + " " + title
+				+ "\n*Announcements*: " + announcement;
 	}
 	
 	public static String printMatches() {

--- a/src/main/java/beans/Vehicle.java
+++ b/src/main/java/beans/Vehicle.java
@@ -9,11 +9,14 @@ public class Vehicle {
 	
 	public static final short YEAR_OLDEST;
 	public static final short YEAR_YOUNGEST;
+	public static final int ODOMETER_MAX;
 	static {
 		YEAR_OLDEST = Short.parseShort(
 				ConfigReader.getProperty("youngerThan"));
 		YEAR_YOUNGEST = Short.parseShort(
 				ConfigReader.getProperty("olderThan"));
+		ODOMETER_MAX = Integer.parseInt(
+				ConfigReader.getProperty("lowerThan"));
 	}
 	
 	private String auction;

--- a/src/main/java/beans/Vehicle.java
+++ b/src/main/java/beans/Vehicle.java
@@ -26,19 +26,24 @@ public class Vehicle {
 	private int odometer;
 	private String vin;
 	private String announcement;
+	private boolean isAvailable;
 	
 	private static List<Vehicle> matches = new ArrayList<Vehicle>();
 	
 	public Vehicle() { }
 	public Vehicle(String auction, String lane, 
-			short year, String title, int odometer, 
-			String announcement) {
+			short year, String title, int odometer,
+			String vin,
+			String announcement,
+			boolean isAvailable) {
 		this.auction = auction;
 		this.lane = lane;
 		this.year = year;
 		this.title = title;
 		this.odometer = odometer;
+		this.vin = vin;
 		this.announcement = announcement;
+		this.isAvailable = isAvailable;
 	}
 	
 	public String getAuction() {
@@ -91,6 +96,12 @@ public class Vehicle {
 			announcement = announcement.replace("Announcements\n", "");
 		this.announcement = announcement;
 	}	
+	public boolean getIsAvailable() {
+		return isAvailable;
+	}
+	public void setIsAvailable(boolean isAvailable) {
+		this.isAvailable = isAvailable;
+	}
 		
 	public static List<Vehicle> getMatches() {
 		return matches;
@@ -104,7 +115,8 @@ public class Vehicle {
 		return auction + "\tLane: " + lane
 				+ "\n" + year + " " + title + " w/ " + odometer + " miles"
 				+ "\n[VIN]: " + vin 
-				+ "\n*Announcements*: " + announcement;
+				+ "\n*Announcements*: " + announcement
+				+ ( isAvailable ? "" : "\n***SOLD***" );
 	}
 	
 	public static String printMatches() {

--- a/src/main/java/beans/Vehicle.java
+++ b/src/main/java/beans/Vehicle.java
@@ -7,10 +7,13 @@ import utilities.ConfigReader;
 
 public class Vehicle {
 	
-	public static final short YEAR_CRITERIA;
+	public static final short YEAR_OLDEST;
+	public static final short YEAR_YOUNGEST;
 	static {
-		YEAR_CRITERIA = Short.parseShort(
+		YEAR_OLDEST = Short.parseShort(
 				ConfigReader.getProperty("youngerThan"));
+		YEAR_YOUNGEST = Short.parseShort(
+				ConfigReader.getProperty("olderThan"));
 	}
 	
 	private String auction;

--- a/src/main/java/pages/AuctionPage.java
+++ b/src/main/java/pages/AuctionPage.java
@@ -39,7 +39,7 @@ public class AuctionPage {
 		String yearText = yearElement.getText();
 		
 		if (yearText == null || yearText.isEmpty()) 
-			return -1;
+			return (short)-1;
 		
 		short year = -1;
 		try {
@@ -67,6 +67,31 @@ public class AuctionPage {
 			return "Unknown";
 		
 		return title;
+	}
+	
+	/**
+	 * Given a current CR Link Element that is in the focus
+	 * the method will go to its main parent that stores the odometer information
+	 * and then will fetch the text and return it as an int.
+	 * Additional internal condition is added if lane box is empty or null
+	 * in which case the method returns -1.
+	 * @param crLinkElement that is currently in focus
+	 * @return int value of the vehicle odometer
+	 */
+	public static int getVehicleOdometer(WebElement crLinkElement) {
+		WebElement odoElement = crLinkElement.findElement(By.xpath("../../../td[5]"));
+		String odoText = odoElement.getText();
+		
+		if (odoText == null || odoText.isEmpty()) 
+			return -1;
+		
+		int odometer = -1;
+		try {
+			odometer = Integer.parseInt(odoText); 
+		} catch (NumberFormatException e) {
+			System.err.println("Couldn't fetch the odometer of the vehicle.");
+		}
+		return odometer;
 	}
 	
 	/**

--- a/src/main/java/pages/AuctionPage.java
+++ b/src/main/java/pages/AuctionPage.java
@@ -71,6 +71,25 @@ public class AuctionPage {
 	
 	/**
 	 * Given a current CR Link Element that is in the focus
+	 * the method will go to its main parent that stores the vehicle VIN
+	 * and then will fetch the text and return it as a String.
+	 * Additional internal condition is added if year box is empty or null
+	 * in which case the method returns n/a.
+	 * @param crLinkElement that is currently in focus
+	 * @return String value of the vehicle VIN
+	 */
+	public static String getVehicleVIN(WebElement crLinkElement) {
+		WebElement vinElement = crLinkElement.findElement(By.xpath("../../span"));
+		String vin = vinElement.getText();
+		
+		if (vin == null || vin.isEmpty()) 
+			return "n/a";
+		
+		return vin;
+	}
+	
+	/**
+	 * Given a current CR Link Element that is in the focus
 	 * the method will go to its main parent that stores the odometer information
 	 * and then will fetch the text and return it as an int.
 	 * Additional internal condition is added if lane box is empty or null

--- a/src/main/java/pages/AuctionPage.java
+++ b/src/main/java/pages/AuctionPage.java
@@ -3,6 +3,7 @@ package pages;
 import java.util.List;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.FindBys;
@@ -129,6 +130,25 @@ public class AuctionPage {
 		if (lane == null || lane.isEmpty()) return "NOT found";
 		
 		return lane;
+	}
+	
+	/**
+	 * Given a current CR Link Element that is in the focus
+	 * the method will go to its main parent that stores the sales status
+	 * and then will try to find fetch proxy bid element, and 
+	 * if found will return true (the vehicle is still available),
+	 * else will return false (the element is replaced, the vehicle is sold).
+	 * @param crLinkElement that is currently in focus
+	 * @return true if proxy element is found, false otherwise
+	 */
+	public static boolean getVehicleIsAvailable(WebElement crLinkElement) {
+		try {
+			crLinkElement.findElement(By.xpath("../../../td[@class='proxyBid']"));
+		} catch (NoSuchElementException e) {
+			return false;
+		}
+		
+		return true;
 	}
 
 }

--- a/src/main/java/pages/AuctionPage.java
+++ b/src/main/java/pages/AuctionPage.java
@@ -52,6 +52,25 @@ public class AuctionPage {
 	
 	/**
 	 * Given a current CR Link Element that is in the focus
+	 * the method will go to its main parent that stores the vehicle title
+	 * and then will fetch the text and return it as a String.
+	 * Additional internal condition is added if year box is empty or null
+	 * in which case the method returns Unknown.
+	 * @param crLinkElement that is currently in focus
+	 * @return String value of the vehicle title
+	 */
+	public static String getVehicleTitle(WebElement crLinkElement) {
+		WebElement titleElement = crLinkElement.findElement(By.xpath("../../a"));
+		String title = titleElement.getText();
+		
+		if (title == null || title.isEmpty()) 
+			return "Unknown";
+		
+		return title;
+	}
+	
+	/**
+	 * Given a current CR Link Element that is in the focus
 	 * the method will go to its main parent that stores the lane information
 	 * and then will fetch the text and return it as a String.
 	 * Additional internal condition is added if lane box is empty or null

--- a/src/main/java/pages/AuctionPage.java
+++ b/src/main/java/pages/AuctionPage.java
@@ -36,11 +36,18 @@ public class AuctionPage {
 	 */
 	public static short getVehicleYear(WebElement crLinkElement) {
 		WebElement yearElement = crLinkElement.findElement(By.xpath("../../../td[2]"));
-		String year = yearElement.getText();
+		String yearText = yearElement.getText();
 		
-		if (year == null || year.isEmpty()) return -1;
+		if (yearText == null || yearText.isEmpty()) 
+			return -1;
 		
-		return Short.parseShort(year);
+		short year = -1;
+		try {
+			year = Short.parseShort(yearText); 
+		} catch (NumberFormatException e) {
+			System.err.println("Couldn't fetch the year of the vehicle.");
+		}
+		return year;
 	}
 	
 	/**

--- a/src/main/java/runner/Main.java
+++ b/src/main/java/runner/Main.java
@@ -109,6 +109,10 @@ System.out.println("LIST OF VEHICLES TO BE EMAILED:\n" + Vehicle.getMatches());
 			String title = AuctionPage.getVehicleTitle(crLinks.get(j));
 			vehicle.setTitle(title);
 			
+			// fetch the VIN of the vehicle
+			String vin = AuctionPage.getVehicleVIN(crLinks.get(j));
+			vehicle.setVIN(vin);
+			
 			// fetch the vehicle odometer information for compatibility
 			int odometer = AuctionPage.getVehicleOdometer(crLinks.get(j));
 			if (odometer > Vehicle.ODOMETER_MAX) continue;

--- a/src/main/java/runner/Main.java
+++ b/src/main/java/runner/Main.java
@@ -100,7 +100,9 @@ System.out.println("LIST OF VEHICLES TO BE EMAILED:\n" + Vehicle.getMatches());
 
 			// fetch the vehicle year for compatibility
 			short year = AuctionPage.getVehicleYear(crLinks.get(j)); 
-			if (year < Vehicle.YEAR_CRITERIA) continue;
+			if (year < Vehicle.YEAR_OLDEST ||
+					year > Vehicle.YEAR_YOUNGEST) 
+				continue;
 			vehicle.setYear(year);
 			
 			// fetch vehicle lane information

--- a/src/main/java/runner/Main.java
+++ b/src/main/java/runner/Main.java
@@ -105,13 +105,17 @@ System.out.println("LIST OF VEHICLES TO BE EMAILED:\n" + Vehicle.getMatches());
 				continue;
 			vehicle.setYear(year);
 			
-			// fetch vehicle lane information
-			String lane = AuctionPage.getVehicleLane(crLinks.get(j));
-			vehicle.setLane(lane);
-			
 			// fetch the vehicle title information
 			String title = AuctionPage.getVehicleTitle(crLinks.get(j));
 			vehicle.setTitle(title);
+			
+			// fetch the vehicle odometer information
+			int odometer = AuctionPage.getVehicleOdometer(crLinks.get(j));
+			vehicle.setOdometer(odometer);
+			
+			// fetch vehicle lane information
+			String lane = AuctionPage.getVehicleLane(crLinks.get(j));
+			vehicle.setLane(lane);
 
 			// store current window information
 			String parentWindow = Driver.getDriver().getWindowHandle();
@@ -130,7 +134,7 @@ System.out.println("LIST OF VEHICLES TO BE EMAILED:\n" + Vehicle.getMatches());
 
 				try {
 					// wait for the new window to finish loading
-					waitForLoad(Driver.getDriver());
+					waitForLoad();
 	
 					// switch to the Frame where vehicle info is stored
 					Driver.getDriver().switchTo().frame("ecrFrame");
@@ -155,7 +159,6 @@ System.out.println("Current vehicle info: " + vehicle.toString());
 
 				// switch back to the parent window
 				Driver.getDriver().switchTo().window(parentWindow);
-				
 			}
 			
 			// limit vehicle count per the email limitation

--- a/src/main/java/runner/Main.java
+++ b/src/main/java/runner/Main.java
@@ -121,7 +121,12 @@ System.out.println("LIST OF VEHICLES TO BE EMAILED:\n" + Vehicle.getMatches());
 			// fetch vehicle lane information
 			String lane = AuctionPage.getVehicleLane(crLinks.get(j));
 			vehicle.setLane(lane);
-
+			
+			// fetch vehicle availability status and continue if SOLD
+			boolean isAvailable = AuctionPage.getVehicleIsAvailable(crLinks.get(j));
+			vehicle.setIsAvailable(isAvailable);
+			if (!isAvailable) continue;
+			
 			// store current window information
 			String parentWindow = Driver.getDriver().getWindowHandle();
 

--- a/src/main/java/runner/Main.java
+++ b/src/main/java/runner/Main.java
@@ -109,8 +109,9 @@ System.out.println("LIST OF VEHICLES TO BE EMAILED:\n" + Vehicle.getMatches());
 			String title = AuctionPage.getVehicleTitle(crLinks.get(j));
 			vehicle.setTitle(title);
 			
-			// fetch the vehicle odometer information
+			// fetch the vehicle odometer information for compatibility
 			int odometer = AuctionPage.getVehicleOdometer(crLinks.get(j));
+			if (odometer > Vehicle.ODOMETER_MAX) continue;
 			vehicle.setOdometer(odometer);
 			
 			// fetch vehicle lane information

--- a/src/main/java/runner/Main.java
+++ b/src/main/java/runner/Main.java
@@ -108,6 +108,10 @@ System.out.println("LIST OF VEHICLES TO BE EMAILED:\n" + Vehicle.getMatches());
 			// fetch vehicle lane information
 			String lane = AuctionPage.getVehicleLane(crLinks.get(j));
 			vehicle.setLane(lane);
+			
+			// fetch the vehicle title information
+			String title = AuctionPage.getVehicleTitle(crLinks.get(j));
+			vehicle.setTitle(title);
 
 			// store current window information
 			String parentWindow = Driver.getDriver().getWindowHandle();


### PR DESCRIPTION
**Release Notes:**

- Introduced new logic to eliminate vehicles younger than certain year
  - The parameter can be adjusted from `application.config`
  - Additional check was placed to eliminate potential code failure in case year of the vehicle is not 
    advertised. Such vehicles are skipped so that the year is assigned as `-1`.
- Vehicle title is being fetched from the `Auction` page instead of from within the CR window. Thus 
  eliminating the need to additional maintenance on the CR window.
  - `Vehicle` to String method is updated accordingly.
  - Code cleanup conducted within the `CRAnalyzer` class.
- Added logic to fetch the vehicle odometer information.
  - Introduced new logic to eliminate vehicles with odometer readings higher than certain parameter 
    defined in `application.config`
- Added logic to fetch the vehicle VIN and parse it with a special design if the VIN is of correct 
  length.
- Added logic to analyze vehicle status (whether it is sold or still available) based on the presence of 
  the 'Proxy bid' element. Currently, vehicles with 'SOLD' status are ignored and no further CR
  analysis is conducted. This logic can be adjusted in the future.